### PR TITLE
Add FIFA World Cup 2026 scores page

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -39,6 +39,12 @@ import { SITE_TITLE } from "../consts";
           <li>
             <HeaderLink
               class={"hover:text-accent dark:hover:text-accent transition-colors"}
+              href="/scores">Scores</HeaderLink
+            >
+          </li>
+          <li>
+            <HeaderLink
+              class={"hover:text-accent dark:hover:text-accent transition-colors"}
               href="/about">About</HeaderLink
             >
           </li>

--- a/src/components/WorldCupChampionBanner.astro
+++ b/src/components/WorldCupChampionBanner.astro
@@ -1,0 +1,77 @@
+---
+import type { TournamentResults } from '../lib/worldcup';
+
+interface Props {
+  results: TournamentResults;
+}
+
+const { results } = Astro.props;
+const { champion, thirdPlace } = results;
+---
+
+<section
+  id="champion-banner"
+  class="section-animate rounded-xl border border-accent/40 bg-gradient-to-br from-accent/10 via-paper/80 to-paper/50 dark:from-accent/15 dark:via-[#2a2520]/80 dark:to-[#1f1b18]/50 p-6 sm:p-8"
+  aria-label="Tournament champion"
+>
+  <p class="text-center text-sm font-medium uppercase tracking-wider text-muted dark:text-gray-400">
+    FIFA World Cup 2026 Champions
+  </p>
+
+  <div class="mt-6 flex flex-col items-center gap-4 text-center">
+    {
+      champion.winner.flag && (
+        <img
+          src={champion.winner.flag}
+          alt=""
+          width="80"
+          height="60"
+          class="h-14 w-20 rounded-md object-cover shadow-sm"
+          loading="eager"
+        />
+      )
+    }
+    <h2
+      id="champion-name"
+      class="text-3xl sm:text-4xl font-bold text-primary dark:text-gray-100 font-serif"
+    >
+      {champion.winner.name}
+    </h2>
+    <p id="champion-score" class="text-lg text-primary/80 dark:text-gray-300 font-mono tabular-nums">
+      Final: {champion.score} vs {champion.runnerUp.name}
+    </p>
+  </div>
+
+  {
+    thirdPlace && (
+      <div
+        id="third-place-banner"
+        class="mt-6 border-t border-border/70 dark:border-[#3d352d]/70 pt-5 text-center"
+      >
+        <p class="text-xs font-semibold uppercase tracking-wider text-muted dark:text-gray-500">
+          Third Place
+        </p>
+        <div class="mt-2 flex items-center justify-center gap-2">
+          {
+            thirdPlace.winner.flag && (
+              <img
+                src={thirdPlace.winner.flag}
+                alt=""
+                width="28"
+                height="21"
+                class="h-[21px] w-7 rounded-sm object-cover"
+                loading="lazy"
+              />
+            )
+          }
+          <p id="third-place-name" class="font-medium text-primary dark:text-gray-200">
+            {thirdPlace.winner.name}
+          </p>
+          <span id="third-place-score" class="text-sm text-muted dark:text-gray-500 font-mono">
+            ({thirdPlace.score})
+          </span>
+        </div>
+      </div>
+    )
+  }
+</section>

--- a/src/components/WorldCupChampionBanner.astro
+++ b/src/components/WorldCupChampionBanner.astro
@@ -1,4 +1,6 @@
 ---
+// Server-render path for the champion banner. Mirrored client-side by
+// createChampionBanner in src/lib/worldcup-render.ts — keep both in sync.
 import type { TournamentResults } from '../lib/worldcup';
 
 interface Props {

--- a/src/components/WorldCupGroupTable.astro
+++ b/src/components/WorldCupGroupTable.astro
@@ -1,0 +1,74 @@
+---
+import type { WCGroup, WCTeam } from '../lib/worldcup';
+
+interface Props {
+  group: WCGroup;
+  teamMap: Map<string, WCTeam>;
+}
+
+const { group, teamMap } = Astro.props;
+
+const sortedTeams = [...group.teams].sort(
+  (a, b) => Number(b.pts) - Number(a.pts) || Number(b.gd) - Number(a.gd)
+);
+---
+
+<section class="rounded-lg border border-border dark:border-[#3d352d] bg-paper/50 dark:bg-[#2a2520]/50 overflow-hidden">
+  <header class="border-b border-border dark:border-[#3d352d] px-4 py-3">
+    <h3 class="text-sm font-semibold uppercase tracking-wider text-primary dark:text-gray-100">
+      Group {group.name}
+    </h3>
+  </header>
+  <div class="overflow-x-auto">
+    <table class="min-w-full text-sm">
+      <thead>
+        <tr class="text-left text-xs uppercase tracking-wider text-muted dark:text-gray-500">
+          <th class="px-4 py-2 font-medium">Team</th>
+          <th class="px-2 py-2 font-medium text-center">P</th>
+          <th class="px-2 py-2 font-medium text-center">W</th>
+          <th class="px-2 py-2 font-medium text-center">D</th>
+          <th class="px-2 py-2 font-medium text-center">L</th>
+          <th class="px-2 py-2 font-medium text-center">GD</th>
+          <th class="px-3 py-2 font-medium text-center">Pts</th>
+        </tr>
+      </thead>
+      <tbody>
+        {
+          sortedTeams.map((standing, index) => {
+            const team = teamMap.get(standing.team_id);
+            return (
+              <tr class="border-t border-border/70 dark:border-[#3d352d]/70">
+                <td class="px-4 py-2.5">
+                  <div class="flex items-center gap-2 min-w-0">
+                    <span class="w-4 text-xs text-muted dark:text-gray-500">{index + 1}</span>
+                    {
+                      team?.flag && (
+                        <img
+                          src={team.flag}
+                          alt=""
+                          width="20"
+                          height="15"
+                          class="h-[15px] w-5 rounded-sm object-cover shrink-0"
+                          loading="lazy"
+                        />
+                      )
+                    }
+                    <span class="font-medium text-primary dark:text-gray-100 truncate">
+                      {team?.name_en ?? `Team ${standing.team_id}`}
+                    </span>
+                  </div>
+                </td>
+                <td class="px-2 py-2.5 text-center tabular-nums">{standing.mp}</td>
+                <td class="px-2 py-2.5 text-center tabular-nums">{standing.w}</td>
+                <td class="px-2 py-2.5 text-center tabular-nums">{standing.d}</td>
+                <td class="px-2 py-2.5 text-center tabular-nums">{standing.l}</td>
+                <td class="px-2 py-2.5 text-center tabular-nums">{standing.gd}</td>
+                <td class="px-3 py-2.5 text-center font-semibold tabular-nums text-accent">{standing.pts}</td>
+              </tr>
+            );
+          })
+        }
+      </tbody>
+    </table>
+  </div>
+</section>

--- a/src/components/WorldCupGroupTable.astro
+++ b/src/components/WorldCupGroupTable.astro
@@ -1,4 +1,6 @@
 ---
+// Server-render path for a group table. Mirrored client-side by createGroupTable
+// in src/lib/worldcup-render.ts for the live-refresh path — keep both in sync.
 import type { WCGroup, WCTeam } from '../lib/worldcup';
 
 interface Props {

--- a/src/components/WorldCupMatchCard.astro
+++ b/src/components/WorldCupMatchCard.astro
@@ -1,4 +1,6 @@
 ---
+// Server-render path for a match card. The live-refresh path rebuilds the same
+// markup client-side in src/lib/worldcup-render.ts (createMatchCard) — keep both in sync.
 import type { WCGame, WCTeam, WCStadium } from '../lib/worldcup';
 import {
   getStageLabel,

--- a/src/components/WorldCupMatchCard.astro
+++ b/src/components/WorldCupMatchCard.astro
@@ -1,0 +1,119 @@
+---
+import type { WCGame, WCTeam, WCStadium } from '../lib/worldcup';
+import {
+  getStageLabel,
+  getStadiumName,
+  getTeamFlag,
+  getTeamName,
+  isFinished,
+  isLive,
+  parseMatchDate,
+} from '../lib/worldcup';
+
+interface Props {
+  game: WCGame;
+  teamMap: Map<string, WCTeam>;
+  stadiumMap: Map<string, WCStadium>;
+}
+
+const { game, teamMap, stadiumMap } = Astro.props;
+
+const homeName = getTeamName(game, 'home', teamMap);
+const awayName = getTeamName(game, 'away', teamMap);
+const homeFlag = getTeamFlag(game, 'home', teamMap);
+const awayFlag = getTeamFlag(game, 'away', teamMap);
+const stadium = getStadiumName(game.stadium_id, stadiumMap);
+const matchDate = parseMatchDate(game.local_date);
+const finished = isFinished(game);
+const live = isLive(game);
+
+const dateLabel = matchDate.toLocaleDateString('en-US', {
+  weekday: 'short',
+  month: 'short',
+  day: 'numeric',
+});
+const timeLabel = matchDate.toLocaleTimeString('en-US', {
+  hour: 'numeric',
+  minute: '2-digit',
+});
+
+const stageLabel = getStageLabel(game.type);
+const groupLabel = game.type === 'group' ? `Group ${game.group}` : game.group;
+---
+
+<article
+  class="worldcup-match card-lift rounded-lg border border-border dark:border-[#3d352d] bg-paper/50 dark:bg-[#2a2520]/50 p-4 sm:p-5"
+  data-match-id={game.id}
+  data-match-type={game.type}
+  data-match-status={live ? 'live' : finished ? 'finished' : 'upcoming'}
+  data-match-date={matchDate.toISOString()}
+>
+  <div class="flex flex-wrap items-center justify-between gap-2 mb-4">
+    <div class="flex flex-wrap items-center gap-2 text-xs font-medium uppercase tracking-wider text-muted dark:text-gray-400">
+      <span>{stageLabel}</span>
+      <span aria-hidden="true">·</span>
+      <span>{groupLabel}</span>
+    </div>
+    {
+      live ? (
+        <span class="inline-flex items-center gap-1.5 rounded-full bg-red-500/15 px-2.5 py-1 text-xs font-semibold uppercase tracking-wide text-red-600 dark:text-red-400">
+          <span class="h-2 w-2 animate-pulse rounded-full bg-red-500" />
+          Live {game.time_elapsed}
+        </span>
+      ) : finished ? (
+        <span class="rounded-full bg-accent/10 px-2.5 py-1 text-xs font-semibold uppercase tracking-wide text-accent">
+          Full Time
+        </span>
+      ) : (
+        <span class="rounded-full border border-border dark:border-[#3d352d] px-2.5 py-1 text-xs font-semibold uppercase tracking-wide text-muted dark:text-gray-400">
+          Upcoming
+        </span>
+      )
+    }
+  </div>
+
+  <div class="grid grid-cols-[1fr_auto_1fr] items-center gap-3 sm:gap-6">
+    <div class="flex flex-col items-end gap-2 text-right min-w-0">
+      <div class="flex items-center justify-end gap-2 min-w-0">
+        <span class="font-medium text-primary dark:text-gray-100 truncate">{homeName}</span>
+        {
+          homeFlag && (
+            <img src={homeFlag} alt="" width="24" height="18" class="h-[18px] w-6 rounded-sm object-cover shrink-0" loading="lazy" />
+          )
+        }
+      </div>
+    </div>
+
+    <div class="text-center shrink-0">
+      {
+        finished || live ? (
+          <p class="text-2xl sm:text-3xl font-bold tabular-nums text-primary dark:text-gray-100 font-mono" data-score>
+            {game.home_score} – {game.away_score}
+          </p>
+        ) : (
+          <p class="text-lg font-semibold text-muted dark:text-gray-400">vs</p>
+        )
+      }
+      <p class="mt-1 text-xs text-muted dark:text-gray-500">
+        {dateLabel} · {timeLabel}
+      </p>
+    </div>
+
+    <div class="flex flex-col items-start gap-2 text-left min-w-0">
+      <div class="flex items-center gap-2 min-w-0">
+        {
+          awayFlag && (
+            <img src={awayFlag} alt="" width="24" height="18" class="h-[18px] w-6 rounded-sm object-cover shrink-0" loading="lazy" />
+          )
+        }
+        <span class="font-medium text-primary dark:text-gray-100 truncate">{awayName}</span>
+      </div>
+    </div>
+  </div>
+
+  {
+    stadium && (
+      <p class="mt-4 text-center text-xs text-muted dark:text-gray-500">{stadium}</p>
+    )
+  }
+</article>

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -5,12 +5,19 @@ import Header from "../components/Header.astro";
 import Footer from "../components/Footer.astro";
 import { SITE_TITLE, SITE_DESCRIPTION } from "../consts";
 import GoogleTag from "../components/GoogleTag.astro";
+
+interface Props {
+  title?: string;
+  description?: string;
+}
+
+const { title = SITE_TITLE, description = SITE_DESCRIPTION } = Astro.props;
 ---
 
 <!doctype html>
 <html lang="en">
   <head>
-    <BaseHead title={SITE_TITLE} description={SITE_DESCRIPTION} />
+    <BaseHead title={title} description={description} />
     <GoogleTag />
   </head>
   <!-- Google tag (gtag.js) -->

--- a/src/lib/worldcup-render.ts
+++ b/src/lib/worldcup-render.ts
@@ -1,0 +1,310 @@
+/**
+ * Client-side DOM builders for the live-refresh path on /scores.
+ *
+ * These mirror the markup of the Astro components used for the initial
+ * server render (WorldCupMatchCard.astro, WorldCupGroupTable.astro,
+ * WorldCupChampionBanner.astro). Keep them visually in sync — the Astro
+ * components own the first paint (SEO / no-JS), these own every refresh.
+ *
+ * Everything is built with createElement/textContent so API-provided
+ * strings can never be interpreted as HTML (no innerHTML interpolation).
+ */
+import type { TournamentResults, WCGame, WCGroup, WCStadium, WCTeam } from './worldcup';
+import {
+  getStadiumName,
+  getStageLabel,
+  getTeamFlag,
+  getTeamName,
+  isFinished,
+  isLive,
+  parseMatchDate,
+} from './worldcup';
+
+type Child = Node | string | null | undefined | false;
+
+function h(tag: string, props: Record<string, string | undefined> = {}, ...children: Child[]): HTMLElement {
+  const node = document.createElement(tag);
+  for (const [key, value] of Object.entries(props)) {
+    if (value === undefined) continue;
+    if (key === 'class') node.className = value;
+    else node.setAttribute(key, value);
+  }
+  for (const child of children) {
+    if (child === null || child === undefined || child === false) continue;
+    node.append(typeof child === 'string' ? document.createTextNode(child) : child);
+  }
+  return node;
+}
+
+function flagImg(src: string, width: number, height: number, className: string, eager = false): HTMLElement {
+  return h('img', {
+    src,
+    alt: '',
+    width: String(width),
+    height: String(height),
+    class: className,
+    loading: eager ? 'eager' : 'lazy',
+  });
+}
+
+export function createMatchCard(
+  game: WCGame,
+  teamMap: Map<string, WCTeam>,
+  stadiumMap: Map<string, WCStadium>
+): HTMLElement {
+  const homeName = getTeamName(game, 'home', teamMap);
+  const awayName = getTeamName(game, 'away', teamMap);
+  const homeFlag = getTeamFlag(game, 'home', teamMap);
+  const awayFlag = getTeamFlag(game, 'away', teamMap);
+  const stadium = getStadiumName(game.stadium_id, stadiumMap);
+  const matchDate = parseMatchDate(game.local_date);
+  const finished = isFinished(game);
+  const live = isLive(game);
+
+  const dateLabel = matchDate.toLocaleDateString('en-US', {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+  });
+  const timeLabel = matchDate.toLocaleTimeString('en-US', {
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+
+  const stageLabel = getStageLabel(game.type);
+  const groupLabel = game.type === 'group' ? `Group ${game.group}` : game.group;
+
+  let statusBadge: HTMLElement;
+  if (live) {
+    statusBadge = h(
+      'span',
+      {
+        class: 'inline-flex items-center gap-1.5 rounded-full bg-red-500/15 px-2.5 py-1 text-xs font-semibold uppercase tracking-wide text-red-600 dark:text-red-400',
+      },
+      h('span', { class: 'h-2 w-2 animate-pulse rounded-full bg-red-500' }),
+      ` Live ${game.time_elapsed}`
+    );
+  } else if (finished) {
+    statusBadge = h(
+      'span',
+      { class: 'rounded-full bg-accent/10 px-2.5 py-1 text-xs font-semibold uppercase tracking-wide text-accent' },
+      'Full Time'
+    );
+  } else {
+    statusBadge = h(
+      'span',
+      {
+        class: 'rounded-full border border-border dark:border-[#3d352d] px-2.5 py-1 text-xs font-semibold uppercase tracking-wide text-muted dark:text-gray-400',
+      },
+      'Upcoming'
+    );
+  }
+
+  const scoreNode =
+    finished || live
+      ? h(
+          'p',
+          {
+            class: 'text-2xl sm:text-3xl font-bold tabular-nums text-primary dark:text-gray-100 font-mono',
+            'data-score': '',
+          },
+          `${game.home_score} – ${game.away_score}`
+        )
+      : h('p', { class: 'text-lg font-semibold text-muted dark:text-gray-400' }, 'vs');
+
+  return h(
+    'article',
+    {
+      class: 'worldcup-match card-lift rounded-lg border border-border dark:border-[#3d352d] bg-paper/50 dark:bg-[#2a2520]/50 p-4 sm:p-5',
+      'data-match-id': game.id,
+      'data-match-type': game.type,
+      'data-match-status': live ? 'live' : finished ? 'finished' : 'upcoming',
+      'data-match-date': matchDate.toISOString(),
+    },
+    h(
+      'div',
+      { class: 'flex flex-wrap items-center justify-between gap-2 mb-4' },
+      h(
+        'div',
+        {
+          class: 'flex flex-wrap items-center gap-2 text-xs font-medium uppercase tracking-wider text-muted dark:text-gray-400',
+        },
+        h('span', {}, stageLabel),
+        h('span', { 'aria-hidden': 'true' }, '·'),
+        h('span', {}, groupLabel)
+      ),
+      statusBadge
+    ),
+    h(
+      'div',
+      { class: 'grid grid-cols-[1fr_auto_1fr] items-center gap-3 sm:gap-6' },
+      h(
+        'div',
+        { class: 'flex flex-col items-end gap-2 text-right min-w-0' },
+        h(
+          'div',
+          { class: 'flex items-center justify-end gap-2 min-w-0' },
+          h('span', { class: 'font-medium text-primary dark:text-gray-100 truncate' }, homeName),
+          homeFlag ? flagImg(homeFlag, 24, 18, 'h-[18px] w-6 rounded-sm object-cover shrink-0') : null
+        )
+      ),
+      h(
+        'div',
+        { class: 'text-center shrink-0' },
+        scoreNode,
+        h('p', { class: 'mt-1 text-xs text-muted dark:text-gray-500' }, `${dateLabel} · ${timeLabel}`)
+      ),
+      h(
+        'div',
+        { class: 'flex flex-col items-start gap-2 text-left min-w-0' },
+        h(
+          'div',
+          { class: 'flex items-center gap-2 min-w-0' },
+          awayFlag ? flagImg(awayFlag, 24, 18, 'h-[18px] w-6 rounded-sm object-cover shrink-0') : null,
+          h('span', { class: 'font-medium text-primary dark:text-gray-100 truncate' }, awayName)
+        )
+      )
+    ),
+    stadium ? h('p', { class: 'mt-4 text-center text-xs text-muted dark:text-gray-500' }, stadium) : null
+  );
+}
+
+export function createGroupTable(group: WCGroup, teamMap: Map<string, WCTeam>): HTMLElement {
+  const sortedTeams = [...group.teams].sort(
+    (a, b) => Number(b.pts) - Number(a.pts) || Number(b.gd) - Number(a.gd)
+  );
+
+  const headerCell = (label: string, className: string) =>
+    h('th', { class: className }, label);
+
+  const rows = sortedTeams.map((standing, index) => {
+    const team = teamMap.get(standing.team_id);
+    return h(
+      'tr',
+      { class: 'border-t border-border/70 dark:border-[#3d352d]/70' },
+      h(
+        'td',
+        { class: 'px-4 py-2.5' },
+        h(
+          'div',
+          { class: 'flex items-center gap-2 min-w-0' },
+          h('span', { class: 'w-4 text-xs text-muted dark:text-gray-500' }, String(index + 1)),
+          team?.flag ? flagImg(team.flag, 20, 15, 'h-[15px] w-5 rounded-sm object-cover shrink-0') : null,
+          h(
+            'span',
+            { class: 'font-medium text-primary dark:text-gray-100 truncate' },
+            team?.name_en ?? `Team ${standing.team_id}`
+          )
+        )
+      ),
+      h('td', { class: 'px-2 py-2.5 text-center tabular-nums' }, standing.mp),
+      h('td', { class: 'px-2 py-2.5 text-center tabular-nums' }, standing.w),
+      h('td', { class: 'px-2 py-2.5 text-center tabular-nums' }, standing.d),
+      h('td', { class: 'px-2 py-2.5 text-center tabular-nums' }, standing.l),
+      h('td', { class: 'px-2 py-2.5 text-center tabular-nums' }, standing.gd),
+      h('td', { class: 'px-3 py-2.5 text-center font-semibold tabular-nums text-accent' }, standing.pts)
+    );
+  });
+
+  return h(
+    'section',
+    { class: 'rounded-lg border border-border dark:border-[#3d352d] bg-paper/50 dark:bg-[#2a2520]/50 overflow-hidden' },
+    h(
+      'header',
+      { class: 'border-b border-border dark:border-[#3d352d] px-4 py-3' },
+      h(
+        'h3',
+        { class: 'text-sm font-semibold uppercase tracking-wider text-primary dark:text-gray-100' },
+        `Group ${group.name}`
+      )
+    ),
+    h(
+      'div',
+      { class: 'overflow-x-auto' },
+      h(
+        'table',
+        { class: 'min-w-full text-sm' },
+        h(
+          'thead',
+          {},
+          h(
+            'tr',
+            { class: 'text-left text-xs uppercase tracking-wider text-muted dark:text-gray-500' },
+            headerCell('Team', 'px-4 py-2 font-medium'),
+            headerCell('P', 'px-2 py-2 font-medium text-center'),
+            headerCell('W', 'px-2 py-2 font-medium text-center'),
+            headerCell('D', 'px-2 py-2 font-medium text-center'),
+            headerCell('L', 'px-2 py-2 font-medium text-center'),
+            headerCell('GD', 'px-2 py-2 font-medium text-center'),
+            headerCell('Pts', 'px-3 py-2 font-medium text-center')
+          )
+        ),
+        h('tbody', {}, ...rows)
+      )
+    )
+  );
+}
+
+export function createChampionBanner(results: TournamentResults): HTMLElement {
+  const { champion, thirdPlace } = results;
+
+  const championBlock = h(
+    'div',
+    { class: 'mt-6 flex flex-col items-center gap-4 text-center' },
+    champion.winner.flag
+      ? flagImg(champion.winner.flag, 80, 60, 'h-14 w-20 rounded-md object-cover shadow-sm', true)
+      : null,
+    h(
+      'h2',
+      { id: 'champion-name', class: 'text-3xl sm:text-4xl font-bold text-primary dark:text-gray-100 font-serif' },
+      champion.winner.name
+    ),
+    h(
+      'p',
+      { id: 'champion-score', class: 'text-lg text-primary/80 dark:text-gray-300 font-mono tabular-nums' },
+      `Final: ${champion.score} vs ${champion.runnerUp.name}`
+    )
+  );
+
+  const thirdPlaceBlock = thirdPlace
+    ? h(
+        'div',
+        {
+          id: 'third-place-banner',
+          class: 'mt-6 border-t border-border/70 dark:border-[#3d352d]/70 pt-5 text-center',
+        },
+        h(
+          'p',
+          { class: 'text-xs font-semibold uppercase tracking-wider text-muted dark:text-gray-500' },
+          'Third Place'
+        ),
+        h(
+          'div',
+          { class: 'mt-2 flex items-center justify-center gap-2' },
+          thirdPlace.winner.flag ? flagImg(thirdPlace.winner.flag, 28, 21, 'h-[21px] w-7 rounded-sm object-cover') : null,
+          h('p', { id: 'third-place-name', class: 'font-medium text-primary dark:text-gray-200' }, thirdPlace.winner.name),
+          h(
+            'span',
+            { id: 'third-place-score', class: 'text-sm text-muted dark:text-gray-500 font-mono' },
+            `(${thirdPlace.score})`
+          )
+        )
+      )
+    : null;
+
+  return h(
+    'section',
+    {
+      id: 'champion-banner',
+      class: 'section-animate rounded-xl border border-accent/40 bg-gradient-to-br from-accent/10 via-paper/80 to-paper/50 dark:from-accent/15 dark:via-[#2a2520]/80 dark:to-[#1f1b18]/50 p-6 sm:p-8',
+      'aria-label': 'Tournament champion',
+    },
+    h(
+      'p',
+      { class: 'text-center text-sm font-medium uppercase tracking-wider text-muted dark:text-gray-400' },
+      'FIFA World Cup 2026 Champions'
+    ),
+    championBlock,
+    thirdPlaceBlock
+  );
+}

--- a/src/lib/worldcup.ts
+++ b/src/lib/worldcup.ts
@@ -157,12 +157,12 @@ export function parseMatchDate(localDate: string): Date {
 }
 
 export function isFinished(game: WCGame): boolean {
-  return game.finished.toUpperCase() === 'TRUE';
+  return String(game.finished ?? '').toUpperCase() === 'TRUE';
 }
 
 export function isLive(game: WCGame): boolean {
   if (isFinished(game)) return false;
-  const elapsed = game.time_elapsed.toLowerCase();
+  const elapsed = String(game.time_elapsed ?? '').toLowerCase();
   return elapsed !== 'notstarted' && elapsed !== 'finished' && elapsed !== '';
 }
 
@@ -214,12 +214,22 @@ export function buildStadiumMap(stadiums: WCStadium[]): Map<string, WCStadium> {
   return new Map(stadiums.map((stadium) => [stadium.id, stadium]));
 }
 
+const FETCH_TIMEOUT_MS = 10_000;
+
 async function fetchJson<T>(endpoint: string): Promise<T> {
-  const response = await fetch(`${WORLDCUP_API_BASE}/${endpoint}`);
-  if (!response.ok) {
-    throw new Error(`World Cup API error (${response.status}) for ${endpoint}`);
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const response = await fetch(`${WORLDCUP_API_BASE}/${endpoint}`, {
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      throw new Error(`World Cup API error (${response.status}) for ${endpoint}`);
+    }
+    return (await response.json()) as T;
+  } finally {
+    clearTimeout(timeout);
   }
-  return response.json() as Promise<T>;
 }
 
 export async function fetchWorldCupData(): Promise<WorldCupData> {

--- a/src/lib/worldcup.ts
+++ b/src/lib/worldcup.ts
@@ -111,6 +111,8 @@ export function getMatchOutcome(
     return { winner: away, runnerUp: home, score };
   }
 
+  // A finished knockout match always has a winner (extra time / penalties if needed).
+  // Equal scores here means the API has not published the final result yet.
   return null;
 }
 

--- a/src/lib/worldcup.ts
+++ b/src/lib/worldcup.ts
@@ -60,6 +60,79 @@ export interface WorldCupData {
   stadiums: WCStadium[];
 }
 
+export interface TeamSummary {
+  name: string;
+  flag?: string;
+}
+
+export interface MatchOutcome {
+  winner: TeamSummary;
+  runnerUp: TeamSummary;
+  score: string;
+}
+
+export interface TournamentResults {
+  champion: MatchOutcome;
+  thirdPlace?: MatchOutcome;
+}
+
+export function getFinalMatch(games: WCGame[]): WCGame | undefined {
+  return games.find((game) => game.type === 'final');
+}
+
+export function getThirdPlaceMatch(games: WCGame[]): WCGame | undefined {
+  return games.find((game) => game.type === 'third');
+}
+
+export function getMatchOutcome(
+  game: WCGame,
+  teamMap: Map<string, WCTeam>
+): MatchOutcome | null {
+  if (!isFinished(game)) return null;
+
+  const homeScore = Number(game.home_score);
+  const awayScore = Number(game.away_score);
+  if (Number.isNaN(homeScore) || Number.isNaN(awayScore)) return null;
+
+  const home: TeamSummary = {
+    name: getTeamName(game, 'home', teamMap),
+    flag: getTeamFlag(game, 'home', teamMap),
+  };
+  const away: TeamSummary = {
+    name: getTeamName(game, 'away', teamMap),
+    flag: getTeamFlag(game, 'away', teamMap),
+  };
+  const score = `${game.home_score} – ${game.away_score}`;
+
+  if (homeScore > awayScore) {
+    return { winner: home, runnerUp: away, score };
+  }
+  if (awayScore > homeScore) {
+    return { winner: away, runnerUp: home, score };
+  }
+
+  return null;
+}
+
+export function getTournamentResults(
+  games: WCGame[],
+  teamMap: Map<string, WCTeam>
+): TournamentResults | null {
+  const finalMatch = getFinalMatch(games);
+  if (!finalMatch) return null;
+
+  const champion = getMatchOutcome(finalMatch, teamMap);
+  if (!champion) return null;
+
+  const thirdPlaceMatch = getThirdPlaceMatch(games);
+  const thirdPlace = thirdPlaceMatch ? getMatchOutcome(thirdPlaceMatch, teamMap) : null;
+
+  return {
+    champion,
+    ...(thirdPlace ? { thirdPlace } : {}),
+  };
+}
+
 const STAGE_LABELS: Record<MatchType, string> = {
   group: 'Group Stage',
   r32: 'Round of 32',

--- a/src/lib/worldcup.ts
+++ b/src/lib/worldcup.ts
@@ -1,0 +1,164 @@
+export const WORLDCUP_API_BASE = 'https://worldcup26.ir/get';
+
+export type MatchType = 'group' | 'r32' | 'r16' | 'qf' | 'sf' | 'third' | 'final';
+
+export interface WCTeam {
+  id: string;
+  name_en: string;
+  iso2: string;
+  flag: string;
+  groups: string;
+}
+
+export interface WCStadium {
+  id: string;
+  name_en: string;
+  city_en: string;
+  country_en: string;
+}
+
+export interface WCGame {
+  id: string;
+  home_team_id: string;
+  away_team_id: string;
+  home_team_name_en?: string;
+  away_team_name_en?: string;
+  home_team_label?: string;
+  away_team_label?: string;
+  home_score: string;
+  away_score: string;
+  group: string;
+  matchday: string;
+  local_date: string;
+  stadium_id: string;
+  finished: string;
+  time_elapsed: string;
+  type: MatchType;
+}
+
+export interface WCGroupTeam {
+  team_id: string;
+  mp: string;
+  w: string;
+  l: string;
+  d: string;
+  pts: string;
+  gf: string;
+  ga: string;
+  gd: string;
+}
+
+export interface WCGroup {
+  name: string;
+  teams: WCGroupTeam[];
+}
+
+export interface WorldCupData {
+  games: WCGame[];
+  teams: WCTeam[];
+  groups: WCGroup[];
+  stadiums: WCStadium[];
+}
+
+const STAGE_LABELS: Record<MatchType, string> = {
+  group: 'Group Stage',
+  r32: 'Round of 32',
+  r16: 'Round of 16',
+  qf: 'Quarter-finals',
+  sf: 'Semi-finals',
+  third: 'Third Place',
+  final: 'Final',
+};
+
+export function getStageLabel(type: string): string {
+  return STAGE_LABELS[type as MatchType] ?? type.toUpperCase();
+}
+
+export function parseMatchDate(localDate: string): Date {
+  const [datePart, timePart = '00:00'] = localDate.split(' ');
+  const [month, day, year] = datePart.split('/').map(Number);
+  const [hours, minutes] = timePart.split(':').map(Number);
+  return new Date(year, month - 1, day, hours, minutes);
+}
+
+export function isFinished(game: WCGame): boolean {
+  return game.finished.toUpperCase() === 'TRUE';
+}
+
+export function isLive(game: WCGame): boolean {
+  if (isFinished(game)) return false;
+  const elapsed = game.time_elapsed.toLowerCase();
+  return elapsed !== 'notstarted' && elapsed !== 'finished' && elapsed !== '';
+}
+
+export function isUpcoming(game: WCGame): boolean {
+  return !isFinished(game) && !isLive(game);
+}
+
+export function getTeamName(
+  game: WCGame,
+  side: 'home' | 'away',
+  teamMap: Map<string, WCTeam>
+): string {
+  const directName = side === 'home' ? game.home_team_name_en : game.away_team_name_en;
+  if (directName) return directName;
+
+  const label = side === 'home' ? game.home_team_label : game.away_team_label;
+  if (label) return label;
+
+  const teamId = side === 'home' ? game.home_team_id : game.away_team_id;
+  return teamMap.get(teamId)?.name_en ?? 'TBD';
+}
+
+export function getTeamFlag(
+  game: WCGame,
+  side: 'home' | 'away',
+  teamMap: Map<string, WCTeam>
+): string | undefined {
+  const teamId = side === 'home' ? game.home_team_id : game.away_team_id;
+  return teamMap.get(teamId)?.flag;
+}
+
+export function getStadiumName(stadiumId: string, stadiumMap: Map<string, WCStadium>): string {
+  const stadium = stadiumMap.get(stadiumId);
+  if (!stadium) return '';
+  return `${stadium.name_en}, ${stadium.city_en}`;
+}
+
+export function sortGamesByDate(games: WCGame[]): WCGame[] {
+  return [...games].sort(
+    (a, b) => parseMatchDate(a.local_date).getTime() - parseMatchDate(b.local_date).getTime()
+  );
+}
+
+export function buildTeamMap(teams: WCTeam[]): Map<string, WCTeam> {
+  return new Map(teams.map((team) => [team.id, team]));
+}
+
+export function buildStadiumMap(stadiums: WCStadium[]): Map<string, WCStadium> {
+  return new Map(stadiums.map((stadium) => [stadium.id, stadium]));
+}
+
+async function fetchJson<T>(endpoint: string): Promise<T> {
+  const response = await fetch(`${WORLDCUP_API_BASE}/${endpoint}`);
+  if (!response.ok) {
+    throw new Error(`World Cup API error (${response.status}) for ${endpoint}`);
+  }
+  return response.json() as Promise<T>;
+}
+
+export async function fetchWorldCupData(): Promise<WorldCupData> {
+  const [gamesPayload, teamsPayload, groupsPayload, stadiumsPayload] = await Promise.all([
+    fetchJson<{ games: WCGame[] }>('games'),
+    fetchJson<{ teams: WCTeam[] }>('teams'),
+    fetchJson<{ groups: WCGroup[] }>('groups'),
+    fetchJson<{ stadiums: WCStadium[] }>('stadiums'),
+  ]);
+
+  return {
+    games: sortGamesByDate(gamesPayload.games),
+    teams: teamsPayload.teams,
+    groups: groupsPayload.groups.sort((a, b) => a.name.localeCompare(b.name)),
+    stadiums: stadiumsPayload.stadiums,
+  };
+}

--- a/src/pages/scores.astro
+++ b/src/pages/scores.astro
@@ -1,11 +1,13 @@
 ---
 import MainLayout from '../layouts/MainLayout.astro';
+import WorldCupChampionBanner from '../components/WorldCupChampionBanner.astro';
 import WorldCupGroupTable from '../components/WorldCupGroupTable.astro';
 import WorldCupMatchCard from '../components/WorldCupMatchCard.astro';
 import {
   buildStadiumMap,
   buildTeamMap,
   fetchWorldCupData,
+  getTournamentResults,
   isFinished,
   isLive,
   isUpcoming,
@@ -30,6 +32,7 @@ const upcomingGames = games.filter(isUpcoming);
 
 const recentResults = [...finishedGames].reverse().slice(0, 6);
 const nextMatches = upcomingGames.slice(0, 6);
+const tournamentResults = data ? getTournamentResults(games, teamMap) : null;
 
 const pageTitle = 'World Cup 2026 Scores - Atiquzzaman Soikat';
 const pageDescription =
@@ -46,6 +49,10 @@ const pageDescription =
         Scores and standings from the 48-team tournament across the United States, Mexico, and Canada.
         Results refresh automatically during matches.
       </p>
+
+      {tournamentResults && <WorldCupChampionBanner results={tournamentResults} />}
+
+      <div id="champion-banner-slot"></div>
 
       {
         data && (
@@ -248,7 +255,9 @@ const pageDescription =
 
 <script>
   import {
+    buildTeamMap,
     fetchWorldCupData,
+    getTournamentResults,
     isFinished,
     isLive,
     isUpcoming,
@@ -330,11 +339,57 @@ const pageDescription =
     });
   }
 
+  function renderChampionBanner(results) {
+    const existingBanner = document.getElementById('champion-banner');
+    const slot = document.getElementById('champion-banner-slot');
+
+    if (!results) {
+      if (existingBanner) existingBanner.remove();
+      if (slot) slot.innerHTML = '';
+      return;
+    }
+
+    const thirdPlaceHtml = results.thirdPlace
+      ? `<div id="third-place-banner" class="mt-6 border-t border-border/70 dark:border-[#3d352d]/70 pt-5 text-center">
+          <p class="text-xs font-semibold uppercase tracking-wider text-muted dark:text-gray-500">Third Place</p>
+          <div class="mt-2 flex items-center justify-center gap-2">
+            ${results.thirdPlace.winner.flag ? `<img src="${results.thirdPlace.winner.flag}" alt="" width="28" height="21" class="h-[21px] w-7 rounded-sm object-cover" />` : ''}
+            <p id="third-place-name" class="font-medium text-primary dark:text-gray-200">${results.thirdPlace.winner.name}</p>
+            <span id="third-place-score" class="text-sm text-muted dark:text-gray-500 font-mono">(${results.thirdPlace.score})</span>
+          </div>
+        </div>`
+      : '';
+
+    const bannerHtml = `
+      <section id="champion-banner" class="section-animate rounded-xl border border-accent/40 bg-gradient-to-br from-accent/10 via-paper/80 to-paper/50 dark:from-accent/15 dark:via-[#2a2520]/80 dark:to-[#1f1b18]/50 p-6 sm:p-8" aria-label="Tournament champion">
+        <p class="text-center text-sm font-medium uppercase tracking-wider text-muted dark:text-gray-400">FIFA World Cup 2026 Champions</p>
+        <div class="mt-6 flex flex-col items-center gap-4 text-center">
+          ${results.champion.winner.flag ? `<img src="${results.champion.winner.flag}" alt="" width="80" height="60" class="h-14 w-20 rounded-md object-cover shadow-sm" />` : ''}
+          <h2 id="champion-name" class="text-3xl sm:text-4xl font-bold text-primary dark:text-gray-100 font-serif">${results.champion.winner.name}</h2>
+          <p id="champion-score" class="text-lg text-primary/80 dark:text-gray-300 font-mono tabular-nums">Final: ${results.champion.score} vs ${results.champion.runnerUp.name}</p>
+        </div>
+        ${thirdPlaceHtml}
+      </section>
+    `;
+
+    if (existingBanner) {
+      existingBanner.outerHTML = bannerHtml;
+    } else if (slot) {
+      slot.innerHTML = bannerHtml;
+    }
+  }
+
+  function updateChampionBanner(data) {
+    const results = getTournamentResults(data.games, buildTeamMap(data.teams));
+    renderChampionBanner(results);
+  }
+
   async function refreshData() {
     try {
       const data = await fetchWorldCupData();
       updateStats(data.games);
       updateMatchCards(data.games);
+      updateChampionBanner(data);
     } catch {
       // Keep existing rendered data if refresh fails.
     }

--- a/src/pages/scores.astro
+++ b/src/pages/scores.astro
@@ -54,36 +54,32 @@ const pageDescription =
 
       <div id="champion-banner-slot"></div>
 
-      {
-        data && (
-          <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-            <div class="rounded-lg border border-border dark:border-[#3d352d] bg-paper/50 dark:bg-[#2a2520]/50 p-4">
-              <p class="text-xs uppercase tracking-wider text-muted dark:text-gray-500">Matches Played</p>
-              <p class="mt-1 text-2xl font-bold text-primary dark:text-gray-100 tabular-nums" id="stat-played">
-                {finishedGames.length}
-              </p>
-            </div>
-            <div class="rounded-lg border border-border dark:border-[#3d352d] bg-paper/50 dark:bg-[#2a2520]/50 p-4">
-              <p class="text-xs uppercase tracking-wider text-muted dark:text-gray-500">Live Now</p>
-              <p class="mt-1 text-2xl font-bold text-red-600 dark:text-red-400 tabular-nums" id="stat-live">
-                {liveGames.length}
-              </p>
-            </div>
-            <div class="rounded-lg border border-border dark:border-[#3d352d] bg-paper/50 dark:bg-[#2a2520]/50 p-4">
-              <p class="text-xs uppercase tracking-wider text-muted dark:text-gray-500">Upcoming</p>
-              <p class="mt-1 text-2xl font-bold text-primary dark:text-gray-100 tabular-nums" id="stat-upcoming">
-                {upcomingGames.length}
-              </p>
-            </div>
-            <div class="rounded-lg border border-border dark:border-[#3d352d] bg-paper/50 dark:bg-[#2a2520]/50 p-4">
-              <p class="text-xs uppercase tracking-wider text-muted dark:text-gray-500">Total Fixtures</p>
-              <p class="mt-1 text-2xl font-bold text-primary dark:text-gray-100 tabular-nums">
-                {games.length}
-              </p>
-            </div>
-          </div>
-        )
-      }
+      <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        <div class="rounded-lg border border-border dark:border-[#3d352d] bg-paper/50 dark:bg-[#2a2520]/50 p-4">
+          <p class="text-xs uppercase tracking-wider text-muted dark:text-gray-500">Matches Played</p>
+          <p class="mt-1 text-2xl font-bold text-primary dark:text-gray-100 tabular-nums" id="stat-played">
+            {finishedGames.length}
+          </p>
+        </div>
+        <div class="rounded-lg border border-border dark:border-[#3d352d] bg-paper/50 dark:bg-[#2a2520]/50 p-4">
+          <p class="text-xs uppercase tracking-wider text-muted dark:text-gray-500">Live Now</p>
+          <p class="mt-1 text-2xl font-bold text-red-600 dark:text-red-400 tabular-nums" id="stat-live">
+            {liveGames.length}
+          </p>
+        </div>
+        <div class="rounded-lg border border-border dark:border-[#3d352d] bg-paper/50 dark:bg-[#2a2520]/50 p-4">
+          <p class="text-xs uppercase tracking-wider text-muted dark:text-gray-500">Upcoming</p>
+          <p class="mt-1 text-2xl font-bold text-primary dark:text-gray-100 tabular-nums" id="stat-upcoming">
+            {upcomingGames.length}
+          </p>
+        </div>
+        <div class="rounded-lg border border-border dark:border-[#3d352d] bg-paper/50 dark:bg-[#2a2520]/50 p-4">
+          <p class="text-xs uppercase tracking-wider text-muted dark:text-gray-500">Total Fixtures</p>
+          <p class="mt-1 text-2xl font-bold text-primary dark:text-gray-100 tabular-nums" id="stat-total">
+            {games.length}
+          </p>
+        </div>
+      </div>
 
       {
         fetchError && (
@@ -103,127 +99,127 @@ const pageDescription =
       </p>
     </section>
 
-    {
-      data && (
-        <>
+    <section
+      class="section-animate space-y-4"
+      id="live-section"
+      style={liveGames.length === 0 ? 'display: none' : undefined}
+    >
+      <h2 class="text-sm font-medium text-muted dark:text-gray-400 uppercase tracking-wider">
+        Live Matches
+      </h2>
+      <div id="live-grid" class="grid gap-4 md:grid-cols-2">
+        {
+          liveGames.map((game) => (
+            <WorldCupMatchCard game={game} teamMap={teamMap} stadiumMap={stadiumMap} />
+          ))
+        }
+      </div>
+    </section>
+
+    <section class="section-animate space-y-6">
+      <div>
+        <h2 class="text-sm font-medium text-muted dark:text-gray-400 uppercase tracking-wider mb-2">
+          Recent Results
+        </h2>
+        <div id="recent-grid" class="grid gap-4 md:grid-cols-2">
           {
-            liveGames.length > 0 && (
-              <section class="section-animate space-y-4">
-                <h2 class="text-sm font-medium text-muted dark:text-gray-400 uppercase tracking-wider">
-                  Live Matches
-                </h2>
-                <div class="grid gap-4 md:grid-cols-2">
-                  {
-                    liveGames.map((game) => (
-                      <WorldCupMatchCard game={game} teamMap={teamMap} stadiumMap={stadiumMap} />
-                    ))
-                  }
-                </div>
-              </section>
-            )
+            recentResults.map((game) => (
+              <WorldCupMatchCard game={game} teamMap={teamMap} stadiumMap={stadiumMap} />
+            ))
           }
+        </div>
+      </div>
 
-          <section class="section-animate space-y-6">
-            <div>
-              <h2 class="text-sm font-medium text-muted dark:text-gray-400 uppercase tracking-wider mb-2">
-                Recent Results
-              </h2>
-              <div class="grid gap-4 md:grid-cols-2">
-                {
-                  recentResults.map((game) => (
-                    <WorldCupMatchCard game={game} teamMap={teamMap} stadiumMap={stadiumMap} />
-                  ))
-                }
-              </div>
-            </div>
+      <div>
+        <h2 class="text-sm font-medium text-muted dark:text-gray-400 uppercase tracking-wider mb-2">
+          Next Fixtures
+        </h2>
+        <div id="next-grid" class="grid gap-4 md:grid-cols-2">
+          {
+            nextMatches.map((game) => (
+              <WorldCupMatchCard game={game} teamMap={teamMap} stadiumMap={stadiumMap} />
+            ))
+          }
+        </div>
+      </div>
+    </section>
 
-            <div>
-              <h2 class="text-sm font-medium text-muted dark:text-gray-400 uppercase tracking-wider mb-2">
-                Next Fixtures
-              </h2>
-              <div class="grid gap-4 md:grid-cols-2">
-                {
-                  nextMatches.map((game) => (
-                    <WorldCupMatchCard game={game} teamMap={teamMap} stadiumMap={stadiumMap} />
-                  ))
-                }
-              </div>
-            </div>
-          </section>
+    <section class="section-animate space-y-4" id="all-matches">
+      <h2 class="text-sm font-medium text-muted dark:text-gray-400 uppercase tracking-wider">
+        All Matches
+      </h2>
+      <div class="flex flex-wrap gap-2" id="match-filters" role="group" aria-label="Filter matches">
+        <button
+          type="button"
+          class="filter-btn active rounded-lg border border-accent bg-accent px-4 py-2 text-sm font-medium text-white"
+          data-filter="all"
+          aria-pressed="true"
+        >
+          All Matches
+        </button>
+        <button
+          type="button"
+          class="filter-btn rounded-lg border border-border dark:border-[#3d352d] px-4 py-2 text-sm font-medium text-primary dark:text-gray-200 hover:border-accent dark:hover:border-accent transition-colors"
+          data-filter="live"
+          aria-pressed="false"
+        >
+          Live
+        </button>
+        <button
+          type="button"
+          class="filter-btn rounded-lg border border-border dark:border-[#3d352d] px-4 py-2 text-sm font-medium text-primary dark:text-gray-200 hover:border-accent dark:hover:border-accent transition-colors"
+          data-filter="results"
+          aria-pressed="false"
+        >
+          Results
+        </button>
+        <button
+          type="button"
+          class="filter-btn rounded-lg border border-border dark:border-[#3d352d] px-4 py-2 text-sm font-medium text-primary dark:text-gray-200 hover:border-accent dark:hover:border-accent transition-colors"
+          data-filter="upcoming"
+          aria-pressed="false"
+        >
+          Upcoming
+        </button>
+        <button
+          type="button"
+          class="filter-btn rounded-lg border border-border dark:border-[#3d352d] px-4 py-2 text-sm font-medium text-primary dark:text-gray-200 hover:border-accent dark:hover:border-accent transition-colors"
+          data-filter="group"
+          aria-pressed="false"
+        >
+          Group Stage
+        </button>
+        <button
+          type="button"
+          class="filter-btn rounded-lg border border-border dark:border-[#3d352d] px-4 py-2 text-sm font-medium text-primary dark:text-gray-200 hover:border-accent dark:hover:border-accent transition-colors"
+          data-filter="knockout"
+          aria-pressed="false"
+        >
+          Knockout
+        </button>
+      </div>
 
-          <section class="section-animate space-y-4" id="all-matches">
-            <h2 class="text-sm font-medium text-muted dark:text-gray-400 uppercase tracking-wider">
-              All Matches
-            </h2>
-            <div class="flex flex-wrap gap-2" id="match-filters" role="tablist" aria-label="Filter matches">
-              <button
-                type="button"
-                class="filter-btn active rounded-lg border border-accent bg-accent px-4 py-2 text-sm font-medium text-white"
-                data-filter="all"
-              >
-                All Matches
-              </button>
-              <button
-                type="button"
-                class="filter-btn rounded-lg border border-border dark:border-[#3d352d] px-4 py-2 text-sm font-medium text-primary dark:text-gray-200 hover:border-accent dark:hover:border-accent transition-colors"
-                data-filter="live"
-              >
-                Live
-              </button>
-              <button
-                type="button"
-                class="filter-btn rounded-lg border border-border dark:border-[#3d352d] px-4 py-2 text-sm font-medium text-primary dark:text-gray-200 hover:border-accent dark:hover:border-accent transition-colors"
-                data-filter="results"
-              >
-                Results
-              </button>
-              <button
-                type="button"
-                class="filter-btn rounded-lg border border-border dark:border-[#3d352d] px-4 py-2 text-sm font-medium text-primary dark:text-gray-200 hover:border-accent dark:hover:border-accent transition-colors"
-                data-filter="upcoming"
-              >
-                Upcoming
-              </button>
-              <button
-                type="button"
-                class="filter-btn rounded-lg border border-border dark:border-[#3d352d] px-4 py-2 text-sm font-medium text-primary dark:text-gray-200 hover:border-accent dark:hover:border-accent transition-colors"
-                data-filter="group"
-              >
-                Group Stage
-              </button>
-              <button
-                type="button"
-                class="filter-btn rounded-lg border border-border dark:border-[#3d352d] px-4 py-2 text-sm font-medium text-primary dark:text-gray-200 hover:border-accent dark:hover:border-accent transition-colors"
-                data-filter="knockout"
-              >
-                Knockout
-              </button>
-            </div>
+      <div id="matches-list" class="grid gap-4">
+        {
+          games.map((game) => (
+            <WorldCupMatchCard game={game} teamMap={teamMap} stadiumMap={stadiumMap} />
+          ))
+        }
+      </div>
+    </section>
 
-            <div id="matches-list" class="grid gap-4">
-              {
-                games.map((game) => (
-                  <WorldCupMatchCard game={game} teamMap={teamMap} stadiumMap={stadiumMap} />
-                ))
-              }
-            </div>
-          </section>
-
-          <section class="section-animate space-y-4">
-            <h2 class="text-sm font-medium text-muted dark:text-gray-400 uppercase tracking-wider">
-              Group Standings
-            </h2>
-            <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-3" id="standings-grid">
-              {
-                data.groups.map((group) => (
-                  <WorldCupGroupTable group={group} teamMap={teamMap} />
-                ))
-              }
-            </div>
-          </section>
-        </>
-      )
-    }
+    <section class="section-animate space-y-4">
+      <h2 class="text-sm font-medium text-muted dark:text-gray-400 uppercase tracking-wider">
+        Group Standings
+      </h2>
+      <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-3" id="standings-grid">
+        {
+          (data?.groups ?? []).map((group) => (
+            <WorldCupGroupTable group={group} teamMap={teamMap} />
+          ))
+        }
+      </div>
+    </section>
 
     <section class="section-animate">
       <p class="text-xs text-muted dark:text-gray-500">
@@ -255,30 +251,34 @@ const pageDescription =
 
 <script>
   import {
+    buildStadiumMap,
     buildTeamMap,
     fetchWorldCupData,
     getTournamentResults,
     isFinished,
     isLive,
     isUpcoming,
+    type WCGame,
+    type WorldCupData,
+    type TournamentResults,
   } from '../lib/worldcup';
+  import {
+    createChampionBanner,
+    createGroupTable,
+    createMatchCard,
+  } from '../lib/worldcup-render';
 
   const REFRESH_INTERVAL_MS = 60_000;
+  const RECENT_LIMIT = 6;
+  const NEXT_LIMIT = 6;
 
-  function getMatchStatus(game) {
-    if (isLive(game)) return 'live';
-    if (isFinished(game)) return 'finished';
-    return 'upcoming';
-  }
+  let currentFilter = 'all';
 
   function applyFilter(filter: string) {
-    const matches = document.querySelectorAll('.worldcup-match');
     const allMatchesSection = document.getElementById('all-matches');
+    if (!allMatchesSection) return;
 
-    matches.forEach((match) => {
-      const inAllMatches = allMatchesSection?.contains(match) ?? false;
-      if (!inAllMatches) return;
-
+    allMatchesSection.querySelectorAll('.worldcup-match').forEach((match) => {
       const status = match.getAttribute('data-match-status');
       const type = match.getAttribute('data-match-type');
       let visible = true;
@@ -294,107 +294,94 @@ const pageDescription =
   }
 
   function setupFilters() {
-    const buttons = document.querySelectorAll('.filter-btn');
+    const buttons = Array.from(document.querySelectorAll<HTMLButtonElement>('.filter-btn'));
     buttons.forEach((button) => {
       button.addEventListener('click', () => {
-        buttons.forEach((btn) => btn.classList.remove('active'));
-        button.classList.add('active');
-        applyFilter(button.getAttribute('data-filter') ?? 'all');
+        currentFilter = button.getAttribute('data-filter') ?? 'all';
+        buttons.forEach((btn) => {
+          const active = btn === button;
+          btn.classList.toggle('active', active);
+          btn.setAttribute('aria-pressed', String(active));
+        });
+        applyFilter(currentFilter);
       });
     });
   }
 
-  function updateStats(games) {
-    const played = games.filter(isFinished).length;
-    const live = games.filter(isLive).length;
-    const upcoming = games.filter(isUpcoming).length;
+  function setText(id: string, value: string | number) {
+    const el = document.getElementById(id);
+    if (el) el.textContent = String(value);
+  }
 
-    const playedEl = document.getElementById('stat-played');
-    const liveEl = document.getElementById('stat-live');
-    const upcomingEl = document.getElementById('stat-upcoming');
-    const updatedEl = document.getElementById('last-updated');
+  function updateStats(games: WCGame[]) {
+    setText('stat-played', games.filter(isFinished).length);
+    setText('stat-live', games.filter(isLive).length);
+    setText('stat-upcoming', games.filter(isUpcoming).length);
+    setText('stat-total', games.length);
 
-    if (playedEl) playedEl.textContent = String(played);
-    if (liveEl) liveEl.textContent = String(live);
-    if (upcomingEl) upcomingEl.textContent = String(upcoming);
-    if (updatedEl) {
-      updatedEl.textContent = `Last updated ${new Date().toLocaleString('en-US', {
+    setText(
+      'last-updated',
+      `Last updated ${new Date().toLocaleString('en-US', {
         dateStyle: 'medium',
         timeStyle: 'short',
-      })}`;
-    }
+      })}`
+    );
   }
 
-  function updateMatchCards(games) {
-    games.forEach((game) => {
-      document.querySelectorAll(`[data-match-id="${game.id}"]`).forEach((card) => {
-        const status = getMatchStatus(game);
-        card.setAttribute('data-match-status', status);
-
-        const scoreEl = card.querySelector('[data-score]');
-        if (scoreEl && (isFinished(game) || isLive(game))) {
-          scoreEl.textContent = `${game.home_score} – ${game.away_score}`;
-        }
-      });
-    });
-  }
-
-  function renderChampionBanner(results) {
+  function renderChampionBanner(results: TournamentResults | null) {
     const existingBanner = document.getElementById('champion-banner');
     const slot = document.getElementById('champion-banner-slot');
 
     if (!results) {
-      if (existingBanner) existingBanner.remove();
-      if (slot) slot.innerHTML = '';
+      existingBanner?.remove();
       return;
     }
 
-    const thirdPlaceHtml = results.thirdPlace
-      ? `<div id="third-place-banner" class="mt-6 border-t border-border/70 dark:border-[#3d352d]/70 pt-5 text-center">
-          <p class="text-xs font-semibold uppercase tracking-wider text-muted dark:text-gray-500">Third Place</p>
-          <div class="mt-2 flex items-center justify-center gap-2">
-            ${results.thirdPlace.winner.flag ? `<img src="${results.thirdPlace.winner.flag}" alt="" width="28" height="21" class="h-[21px] w-7 rounded-sm object-cover" />` : ''}
-            <p id="third-place-name" class="font-medium text-primary dark:text-gray-200">${results.thirdPlace.winner.name}</p>
-            <span id="third-place-score" class="text-sm text-muted dark:text-gray-500 font-mono">(${results.thirdPlace.score})</span>
-          </div>
-        </div>`
-      : '';
-
-    const bannerHtml = `
-      <section id="champion-banner" class="section-animate rounded-xl border border-accent/40 bg-gradient-to-br from-accent/10 via-paper/80 to-paper/50 dark:from-accent/15 dark:via-[#2a2520]/80 dark:to-[#1f1b18]/50 p-6 sm:p-8" aria-label="Tournament champion">
-        <p class="text-center text-sm font-medium uppercase tracking-wider text-muted dark:text-gray-400">FIFA World Cup 2026 Champions</p>
-        <div class="mt-6 flex flex-col items-center gap-4 text-center">
-          ${results.champion.winner.flag ? `<img src="${results.champion.winner.flag}" alt="" width="80" height="60" class="h-14 w-20 rounded-md object-cover shadow-sm" />` : ''}
-          <h2 id="champion-name" class="text-3xl sm:text-4xl font-bold text-primary dark:text-gray-100 font-serif">${results.champion.winner.name}</h2>
-          <p id="champion-score" class="text-lg text-primary/80 dark:text-gray-300 font-mono tabular-nums">Final: ${results.champion.score} vs ${results.champion.runnerUp.name}</p>
-        </div>
-        ${thirdPlaceHtml}
-      </section>
-    `;
-
-    if (existingBanner) {
-      existingBanner.outerHTML = bannerHtml;
-    } else if (slot) {
-      slot.innerHTML = bannerHtml;
-    }
+    const banner = createChampionBanner(results);
+    if (existingBanner) existingBanner.replaceWith(banner);
+    else slot?.replaceChildren(banner);
   }
 
-  function updateChampionBanner(data) {
-    const results = getTournamentResults(data.games, buildTeamMap(data.teams));
-    renderChampionBanner(results);
+  function fillSection(id: string, nodes: Node[]) {
+    document.getElementById(id)?.replaceChildren(...nodes);
+  }
+
+  function render(data: WorldCupData) {
+    const teamMap = buildTeamMap(data.teams);
+    const stadiumMap = buildStadiumMap(data.stadiums);
+    const games = data.games;
+    const card = (game: WCGame) => createMatchCard(game, teamMap, stadiumMap);
+
+    const liveGames = games.filter(isLive);
+    const finishedGames = games.filter(isFinished);
+    const upcomingGames = games.filter(isUpcoming);
+
+    fillSection('live-grid', liveGames.map(card));
+    const liveSection = document.getElementById('live-section');
+    if (liveSection) liveSection.style.display = liveGames.length > 0 ? '' : 'none';
+
+    fillSection('recent-grid', [...finishedGames].reverse().slice(0, RECENT_LIMIT).map(card));
+    fillSection('next-grid', upcomingGames.slice(0, NEXT_LIMIT).map(card));
+    fillSection('matches-list', games.map(card));
+    fillSection(
+      'standings-grid',
+      data.groups.map((group) => createGroupTable(group, teamMap))
+    );
+
+    updateStats(games);
+    renderChampionBanner(getTournamentResults(games, teamMap));
+    applyFilter(currentFilter);
   }
 
   async function refreshData() {
     try {
-      const data = await fetchWorldCupData();
-      updateStats(data.games);
-      updateMatchCards(data.games);
-      updateChampionBanner(data);
+      render(await fetchWorldCupData());
     } catch {
-      // Keep existing rendered data if refresh fails.
+      // Keep the existing rendered snapshot if a refresh fails.
     }
   }
 
   setupFilters();
+  refreshData();
   window.setInterval(refreshData, REFRESH_INTERVAL_MS);
 </script>

--- a/src/pages/scores.astro
+++ b/src/pages/scores.astro
@@ -1,0 +1,345 @@
+---
+import MainLayout from '../layouts/MainLayout.astro';
+import WorldCupGroupTable from '../components/WorldCupGroupTable.astro';
+import WorldCupMatchCard from '../components/WorldCupMatchCard.astro';
+import {
+  buildStadiumMap,
+  buildTeamMap,
+  fetchWorldCupData,
+  isFinished,
+  isLive,
+  isUpcoming,
+} from '../lib/worldcup';
+
+let data;
+let fetchError: string | null = null;
+
+try {
+  data = await fetchWorldCupData();
+} catch (error) {
+  fetchError = error instanceof Error ? error.message : 'Unable to load World Cup data.';
+}
+
+const teamMap = data ? buildTeamMap(data.teams) : new Map();
+const stadiumMap = data ? buildStadiumMap(data.stadiums) : new Map();
+
+const games = data?.games ?? [];
+const liveGames = games.filter(isLive);
+const finishedGames = games.filter(isFinished);
+const upcomingGames = games.filter(isUpcoming);
+
+const recentResults = [...finishedGames].reverse().slice(0, 6);
+const nextMatches = upcomingGames.slice(0, 6);
+
+const pageTitle = 'World Cup 2026 Scores - Atiquzzaman Soikat';
+const pageDescription =
+  'Live scores, results, and group standings for the FIFA World Cup 2026 in USA, Canada, and Mexico.';
+---
+
+<MainLayout title={pageTitle} description={pageDescription}>
+  <article class="space-y-12">
+    <section class="section-animate space-y-4">
+      <p class="text-xl text-primary dark:text-gray-200 font-semibold">
+        FIFA World Cup 2026
+      </p>
+      <p class="text-lg text-primary/80 dark:text-gray-300 leading-relaxed max-w-3xl">
+        Scores and standings from the 48-team tournament across the United States, Mexico, and Canada.
+        Results refresh automatically during matches.
+      </p>
+
+      {
+        data && (
+          <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            <div class="rounded-lg border border-border dark:border-[#3d352d] bg-paper/50 dark:bg-[#2a2520]/50 p-4">
+              <p class="text-xs uppercase tracking-wider text-muted dark:text-gray-500">Matches Played</p>
+              <p class="mt-1 text-2xl font-bold text-primary dark:text-gray-100 tabular-nums" id="stat-played">
+                {finishedGames.length}
+              </p>
+            </div>
+            <div class="rounded-lg border border-border dark:border-[#3d352d] bg-paper/50 dark:bg-[#2a2520]/50 p-4">
+              <p class="text-xs uppercase tracking-wider text-muted dark:text-gray-500">Live Now</p>
+              <p class="mt-1 text-2xl font-bold text-red-600 dark:text-red-400 tabular-nums" id="stat-live">
+                {liveGames.length}
+              </p>
+            </div>
+            <div class="rounded-lg border border-border dark:border-[#3d352d] bg-paper/50 dark:bg-[#2a2520]/50 p-4">
+              <p class="text-xs uppercase tracking-wider text-muted dark:text-gray-500">Upcoming</p>
+              <p class="mt-1 text-2xl font-bold text-primary dark:text-gray-100 tabular-nums" id="stat-upcoming">
+                {upcomingGames.length}
+              </p>
+            </div>
+            <div class="rounded-lg border border-border dark:border-[#3d352d] bg-paper/50 dark:bg-[#2a2520]/50 p-4">
+              <p class="text-xs uppercase tracking-wider text-muted dark:text-gray-500">Total Fixtures</p>
+              <p class="mt-1 text-2xl font-bold text-primary dark:text-gray-100 tabular-nums">
+                {games.length}
+              </p>
+            </div>
+          </div>
+        )
+      }
+
+      {
+        fetchError && (
+          <div class="rounded-lg border border-red-300/60 bg-red-50 dark:bg-red-950/30 dark:border-red-800/60 p-4 text-red-800 dark:text-red-300">
+            <p class="font-medium">Could not load tournament data</p>
+            <p class="mt-1 text-sm">{fetchError}</p>
+          </div>
+        )
+      }
+
+      <p class="text-xs text-muted dark:text-gray-500" id="last-updated">
+        {
+          data
+            ? `Last updated ${new Date().toLocaleString('en-US', { dateStyle: 'medium', timeStyle: 'short' })}`
+            : ''
+        }
+      </p>
+    </section>
+
+    {
+      data && (
+        <>
+          {
+            liveGames.length > 0 && (
+              <section class="section-animate space-y-4">
+                <h2 class="text-sm font-medium text-muted dark:text-gray-400 uppercase tracking-wider">
+                  Live Matches
+                </h2>
+                <div class="grid gap-4 md:grid-cols-2">
+                  {
+                    liveGames.map((game) => (
+                      <WorldCupMatchCard game={game} teamMap={teamMap} stadiumMap={stadiumMap} />
+                    ))
+                  }
+                </div>
+              </section>
+            )
+          }
+
+          <section class="section-animate space-y-6">
+            <div>
+              <h2 class="text-sm font-medium text-muted dark:text-gray-400 uppercase tracking-wider mb-2">
+                Recent Results
+              </h2>
+              <div class="grid gap-4 md:grid-cols-2">
+                {
+                  recentResults.map((game) => (
+                    <WorldCupMatchCard game={game} teamMap={teamMap} stadiumMap={stadiumMap} />
+                  ))
+                }
+              </div>
+            </div>
+
+            <div>
+              <h2 class="text-sm font-medium text-muted dark:text-gray-400 uppercase tracking-wider mb-2">
+                Next Fixtures
+              </h2>
+              <div class="grid gap-4 md:grid-cols-2">
+                {
+                  nextMatches.map((game) => (
+                    <WorldCupMatchCard game={game} teamMap={teamMap} stadiumMap={stadiumMap} />
+                  ))
+                }
+              </div>
+            </div>
+          </section>
+
+          <section class="section-animate space-y-4" id="all-matches">
+            <h2 class="text-sm font-medium text-muted dark:text-gray-400 uppercase tracking-wider">
+              All Matches
+            </h2>
+            <div class="flex flex-wrap gap-2" id="match-filters" role="tablist" aria-label="Filter matches">
+              <button
+                type="button"
+                class="filter-btn active rounded-lg border border-accent bg-accent px-4 py-2 text-sm font-medium text-white"
+                data-filter="all"
+              >
+                All Matches
+              </button>
+              <button
+                type="button"
+                class="filter-btn rounded-lg border border-border dark:border-[#3d352d] px-4 py-2 text-sm font-medium text-primary dark:text-gray-200 hover:border-accent dark:hover:border-accent transition-colors"
+                data-filter="live"
+              >
+                Live
+              </button>
+              <button
+                type="button"
+                class="filter-btn rounded-lg border border-border dark:border-[#3d352d] px-4 py-2 text-sm font-medium text-primary dark:text-gray-200 hover:border-accent dark:hover:border-accent transition-colors"
+                data-filter="results"
+              >
+                Results
+              </button>
+              <button
+                type="button"
+                class="filter-btn rounded-lg border border-border dark:border-[#3d352d] px-4 py-2 text-sm font-medium text-primary dark:text-gray-200 hover:border-accent dark:hover:border-accent transition-colors"
+                data-filter="upcoming"
+              >
+                Upcoming
+              </button>
+              <button
+                type="button"
+                class="filter-btn rounded-lg border border-border dark:border-[#3d352d] px-4 py-2 text-sm font-medium text-primary dark:text-gray-200 hover:border-accent dark:hover:border-accent transition-colors"
+                data-filter="group"
+              >
+                Group Stage
+              </button>
+              <button
+                type="button"
+                class="filter-btn rounded-lg border border-border dark:border-[#3d352d] px-4 py-2 text-sm font-medium text-primary dark:text-gray-200 hover:border-accent dark:hover:border-accent transition-colors"
+                data-filter="knockout"
+              >
+                Knockout
+              </button>
+            </div>
+
+            <div id="matches-list" class="grid gap-4">
+              {
+                games.map((game) => (
+                  <WorldCupMatchCard game={game} teamMap={teamMap} stadiumMap={stadiumMap} />
+                ))
+              }
+            </div>
+          </section>
+
+          <section class="section-animate space-y-4">
+            <h2 class="text-sm font-medium text-muted dark:text-gray-400 uppercase tracking-wider">
+              Group Standings
+            </h2>
+            <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-3" id="standings-grid">
+              {
+                data.groups.map((group) => (
+                  <WorldCupGroupTable group={group} teamMap={teamMap} />
+                ))
+              }
+            </div>
+          </section>
+        </>
+      )
+    }
+
+    <section class="section-animate">
+      <p class="text-xs text-muted dark:text-gray-500">
+        Match data provided by the open
+        <a
+          href="https://worldcup26.ir/api-docs/"
+          class="text-accent hover:underline"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          World Cup 2026 API
+        </a>.
+      </p>
+    </section>
+  </article>
+</MainLayout>
+
+<style>
+  .filter-btn.active {
+    border-color: var(--accent);
+    background-color: var(--accent);
+    color: white;
+  }
+
+  .worldcup-match.hidden-match {
+    display: none;
+  }
+</style>
+
+<script>
+  import {
+    fetchWorldCupData,
+    isFinished,
+    isLive,
+    isUpcoming,
+  } from '../lib/worldcup';
+
+  const REFRESH_INTERVAL_MS = 60_000;
+
+  function getMatchStatus(game) {
+    if (isLive(game)) return 'live';
+    if (isFinished(game)) return 'finished';
+    return 'upcoming';
+  }
+
+  function applyFilter(filter: string) {
+    const matches = document.querySelectorAll('.worldcup-match');
+    const allMatchesSection = document.getElementById('all-matches');
+
+    matches.forEach((match) => {
+      const inAllMatches = allMatchesSection?.contains(match) ?? false;
+      if (!inAllMatches) return;
+
+      const status = match.getAttribute('data-match-status');
+      const type = match.getAttribute('data-match-type');
+      let visible = true;
+
+      if (filter === 'live') visible = status === 'live';
+      else if (filter === 'results') visible = status === 'finished';
+      else if (filter === 'upcoming') visible = status === 'upcoming';
+      else if (filter === 'group') visible = type === 'group';
+      else if (filter === 'knockout') visible = type !== 'group';
+
+      match.classList.toggle('hidden-match', !visible);
+    });
+  }
+
+  function setupFilters() {
+    const buttons = document.querySelectorAll('.filter-btn');
+    buttons.forEach((button) => {
+      button.addEventListener('click', () => {
+        buttons.forEach((btn) => btn.classList.remove('active'));
+        button.classList.add('active');
+        applyFilter(button.getAttribute('data-filter') ?? 'all');
+      });
+    });
+  }
+
+  function updateStats(games) {
+    const played = games.filter(isFinished).length;
+    const live = games.filter(isLive).length;
+    const upcoming = games.filter(isUpcoming).length;
+
+    const playedEl = document.getElementById('stat-played');
+    const liveEl = document.getElementById('stat-live');
+    const upcomingEl = document.getElementById('stat-upcoming');
+    const updatedEl = document.getElementById('last-updated');
+
+    if (playedEl) playedEl.textContent = String(played);
+    if (liveEl) liveEl.textContent = String(live);
+    if (upcomingEl) upcomingEl.textContent = String(upcoming);
+    if (updatedEl) {
+      updatedEl.textContent = `Last updated ${new Date().toLocaleString('en-US', {
+        dateStyle: 'medium',
+        timeStyle: 'short',
+      })}`;
+    }
+  }
+
+  function updateMatchCards(games) {
+    games.forEach((game) => {
+      document.querySelectorAll(`[data-match-id="${game.id}"]`).forEach((card) => {
+        const status = getMatchStatus(game);
+        card.setAttribute('data-match-status', status);
+
+        const scoreEl = card.querySelector('[data-score]');
+        if (scoreEl && (isFinished(game) || isLive(game))) {
+          scoreEl.textContent = `${game.home_score} – ${game.away_score}`;
+        }
+      });
+    });
+  }
+
+  async function refreshData() {
+    try {
+      const data = await fetchWorldCupData();
+      updateStats(data.games);
+      updateMatchCards(data.games);
+    } catch {
+      // Keep existing rendered data if refresh fails.
+    }
+  }
+
+  setupFilters();
+  window.setInterval(refreshData, REFRESH_INTERVAL_MS);
+</script>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a new `/scores` page that displays FIFA World Cup 2026 match results, upcoming fixtures, and group standings.

- Fetches tournament data from the open [World Cup 2026 API](https://worldcup26.ir/api-docs/) at build time and refreshes scores client-side every 60 seconds
- Shows summary stats (matches played, live, upcoming, total fixtures)
- Highlights recent results and next fixtures
- Provides a filterable full fixture list (all, live, results, upcoming, group stage, knockout)
- Displays all 12 group standings tables with flags and points
- **Automatically shows the tournament champion** once the final is marked finished in the API (with third-place team when available)
- Adds a **Scores** link to the site header
- Updates `MainLayout` to accept optional `title` and `description` props for page-specific SEO

## New files

- `src/pages/scores.astro` — main scores page
- `src/lib/worldcup.ts` — API client and helpers
- `src/components/WorldCupMatchCard.astro` — match result card
- `src/components/WorldCupGroupTable.astro` — group standings table
- `src/components/WorldCupChampionBanner.astro` — champion banner shown after the final

## Test plan

- [x] `pnpm build` succeeds and generates `/scores/index.html`
- [x] Visit `/scores` locally with `pnpm dev` and verify match data renders
- [x] Confirm filter buttons show/hide matches in the full fixture list
- [x] Confirm header **Scores** link navigates to the new page
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1490-311a-7b35-ab43-69312d9d1762"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1490-311a-7b35-ab43-69312d9d1762"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

